### PR TITLE
Rescue Errno::ESRCH when checking process memory

### DIFF
--- a/lib/kimurai/capybara_ext/driver/base.rb
+++ b/lib/kimurai/capybara_ext/driver/base.rb
@@ -49,7 +49,7 @@ class Capybara::Driver::Base
 
           sum
         end
-      rescue Errno::EACCES
+      rescue Errno::EACCES, Errno::ESRCH
         0
       end
     when "darwin"


### PR DESCRIPTION
This adds a check in Capybara's driver to handle an `Errno::ESRCH` exception while checking the process memory of the crawler.